### PR TITLE
[Server/feat] : mongo db index

### DIFF
--- a/server/internal/pkg/database/mongodb/indexes.go
+++ b/server/internal/pkg/database/mongodb/indexes.go
@@ -1,0 +1,37 @@
+package mongodb
+
+import (
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type CollectionIndexes struct {
+	Name    string
+	Indexes []mongo.IndexModel
+}
+
+var MenuIndexes CollectionIndexes = CollectionIndexes{
+	Name: "menu",
+	Indexes: []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "store_code", Value: 1},
+				{Key: "category", Value: 1},
+			},
+			Options: options.Index().SetName("Menu_storeCode_category_Index"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "store_code", Value: 1},
+				{Key: "category", Value: 1},
+				{Key: "name", Value: 1},
+			},
+			Options: options.Index().SetName("Menu_storeCode_category_name_Index").SetUnique(true),
+		},
+	},
+}
+
+var indexes []CollectionIndexes = []CollectionIndexes{
+	MenuIndexes,
+}

--- a/server/internal/pkg/database/mongodb/main.go
+++ b/server/internal/pkg/database/mongodb/main.go
@@ -49,6 +49,19 @@ func Initialize() {
 		//}
 
 		defineCollections()
-		// index 생성 할까? 말까?
+		createIndexes()
 	})
+}
+
+func createIndexes() {
+	for _, colIdx := range indexes {
+		coll := Client.Database(name).Collection(colIdx.Name)
+
+		_, err := coll.Indexes().CreateMany(context.Background(), colIdx.Indexes)
+		if err != nil {
+			logrus.Errorf("❌ Failed to create indexes for collection %s: %v", colIdx.Name, err)
+		} else {
+			logrus.Infof("✅ Indexes created for collection %s", colIdx.Name)
+		}
+	}
 }


### PR DESCRIPTION
## 연관된 이슈
#58 

## 요약
* MenuIndex 추가 
* mongo initialize 에 createindex 추가
* 이후 curl --location 'http://localhost:8080/api/rest/menu/5fjVwE8z/menuList?category=coffee' & curl --location 'http://localhost:8080/api/rest/menu/5fjVwE8z/menuList?category=coffee' & ... &... & 로 병렬 요청 테스트 

## 상세 
* index 도입 전 
![image](https://github.com/user-attachments/assets/1cd2264b-4393-4564-a1e2-dee89c02db96)


* index 도입 이후
![image](https://github.com/user-attachments/assets/7ff7fc38-cf77-41f5-9a65-d5bfeef19f06)

인덱스 없음 평균: 약 490ms

인덱스 있음 평균: 약 350ms

📌 약 28% 응답 속도 향상

