### PR TITLE
Server/refactor/store_code_validation : StoreCode 검증 로직 구현 및 추가

### DIFF
--- a/proto/error.proto
+++ b/proto/error.proto
@@ -9,6 +9,7 @@ enum EError {
   EE_API_AUTH_FAILED = 10001;
 
   // store
+  EE_STORE_NOT_FOUND = 20001;
 
   // inquiry
   EE_INQUIRY_STREAM_FAILED = 30000;

--- a/server/gen/error.pb.go
+++ b/server/gen/error.pb.go
@@ -27,6 +27,8 @@ const (
 	EError_EE_UNSPECIFIED     EError = 0
 	EError_EE_API_FAILED      EError = 10000
 	EError_EE_API_AUTH_FAILED EError = 10001
+	// store
+	EError_EE_STORE_NOT_FOUND EError = 20001
 	// inquiry
 	EError_EE_INQUIRY_STREAM_FAILED EError = 30000
 )
@@ -37,12 +39,14 @@ var (
 		0:     "EE_UNSPECIFIED",
 		10000: "EE_API_FAILED",
 		10001: "EE_API_AUTH_FAILED",
+		20001: "EE_STORE_NOT_FOUND",
 		30000: "EE_INQUIRY_STREAM_FAILED",
 	}
 	EError_value = map[string]int32{
 		"EE_UNSPECIFIED":           0,
 		"EE_API_FAILED":            10000,
 		"EE_API_AUTH_FAILED":       10001,
+		"EE_STORE_NOT_FOUND":       20001,
 		"EE_INQUIRY_STREAM_FAILED": 30000,
 	}
 )
@@ -78,11 +82,12 @@ var File_error_proto protoreflect.FileDescriptor
 
 const file_error_proto_rawDesc = "" +
 	"\n" +
-	"\verror.proto*i\n" +
+	"\verror.proto*\x83\x01\n" +
 	"\x06EError\x12\x12\n" +
 	"\x0eEE_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\rEE_API_FAILED\x10\x90N\x12\x17\n" +
-	"\x12EE_API_AUTH_FAILED\x10\x91N\x12\x1e\n" +
+	"\x12EE_API_AUTH_FAILED\x10\x91N\x12\x18\n" +
+	"\x12EE_STORE_NOT_FOUND\x10\xa1\x9c\x01\x12\x1e\n" +
 	"\x18EE_INQUIRY_STREAM_FAILED\x10\xb0\xea\x01B\x18Z\x16capstone-2025-30/protob\x06proto3"
 
 var (

--- a/server/internal/pkg/database/mongodb/menu/crud.go
+++ b/server/internal/pkg/database/mongodb/menu/crud.go
@@ -3,6 +3,7 @@ package menustore
 import (
 	"context"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"server/internal/pkg/database/mongodb"
 	dbstructure "server/internal/pkg/database/structure"
@@ -24,8 +25,8 @@ func CreateMMenu(mMenu *dbstructure.MMenu) error {
 	return err
 }
 
-func GetCategoryList(storeCode string) ([]string, error) {
-	filter := bson.M{"store_code": storeCode}
+func GetCategoryList(storeID primitive.ObjectID) ([]string, error) {
+	filter := bson.M{"store_id": storeID}
 	ctx := context.Background()
 
 	results, err := mongodb.MenuColl.Distinct(ctx, "category", filter)
@@ -43,10 +44,10 @@ func GetCategoryList(storeCode string) ([]string, error) {
 	return categories, nil
 }
 
-func GetMMenuList(storeCode string, category string) ([]dbstructure.MMenu, error) {
+func GetMMenuList(storeID primitive.ObjectID, category string) ([]dbstructure.MMenu, error) {
 	filter := bson.M{
-		"store_code": storeCode,
-		"category":   category,
+		"store_id": storeID,
+		"category": category,
 	}
 
 	cursor, err := mongodb.MenuColl.Find(context.Background(), filter)
@@ -67,11 +68,11 @@ func GetMMenuList(storeCode string, category string) ([]dbstructure.MMenu, error
 	return menus, nil
 }
 
-func GetMMenuDetail(storeCode, category, menu string) (*dbstructure.MMenu, error) {
+func GetMMenuDetail(storeID primitive.ObjectID, category, menu string) (*dbstructure.MMenu, error) {
 	filter := bson.M{
-		"store_code": storeCode,
-		"category":   category,
-		"name":       menu,
+		"store_id": storeID,
+		"category": category,
+		"name":     menu,
 	}
 
 	var result dbstructure.MMenu
@@ -85,10 +86,10 @@ func GetMMenuDetail(storeCode, category, menu string) (*dbstructure.MMenu, error
 	return &result, nil
 }
 
-func FindMenuImage(storeCode string, name string) (string, error) {
+func FindMenuImage(storeID primitive.ObjectID, name string) (string, error) {
 	filter := bson.M{
-		"store_code": storeCode,
-		"name":       name,
+		"store_id": storeID,
+		"name":     name,
 	}
 
 	var result struct {

--- a/server/internal/pkg/database/mongodb/order/crud.go
+++ b/server/internal/pkg/database/mongodb/order/crud.go
@@ -3,6 +3,7 @@ package morder
 import (
 	"context"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	pb "server/gen"
@@ -38,9 +39,9 @@ func CreateMOrder(mOrder *dbstructure.MOrder) error {
 	return err
 }
 
-func GetMOrderStatus(storeCode string, orderNumber int32) (*dbstructure.MOrder, error) {
+func GetMOrderStatus(storeID primitive.ObjectID, orderNumber int32) (*dbstructure.MOrder, error) {
 	filter := bson.M{
-		"store_code":   storeCode,
+		"store_id":     storeID,
 		"order_number": orderNumber,
 	}
 
@@ -57,8 +58,8 @@ func GetMOrderStatus(storeCode string, orderNumber int32) (*dbstructure.MOrder, 
 	return &order, nil
 }
 
-func GetMOrderList(storeCode string) ([]dbstructure.MOrder, error) {
-	filter := bson.M{"store_code": storeCode}
+func GetMOrderList(storeID primitive.ObjectID) ([]dbstructure.MOrder, error) {
+	filter := bson.M{"store_id": storeID}
 	ctx := context.Background()
 
 	opts := options.Find().SetSort(bson.D{{"created_at", -1}}).SetLimit(100)
@@ -81,7 +82,7 @@ func GetMOrderList(storeCode string) ([]dbstructure.MOrder, error) {
 	return orders, nil
 }
 
-func UpdateMOrderStatus(storeCode string, orderNumber int32, newStatus pb.OrderStatus) error {
+func UpdateMOrderStatus(storeID primitive.ObjectID, orderNumber int32, newStatus pb.OrderStatus) error {
 	session, err := mongodb.Client.StartSession()
 	if err != nil {
 		return err
@@ -90,7 +91,7 @@ func UpdateMOrderStatus(storeCode string, orderNumber int32, newStatus pb.OrderS
 
 	callback := func(sc mongo.SessionContext) (interface{}, error) {
 		filter := bson.M{
-			"store_code":   storeCode,
+			"store_id":     storeID,
 			"order_number": orderNumber,
 		}
 		update := bson.M{

--- a/server/internal/pkg/database/mongodb/store/validator.go
+++ b/server/internal/pkg/database/mongodb/store/validator.go
@@ -1,4 +1,4 @@
-package mauth
+package mstore
 
 import (
 	"context"
@@ -8,13 +8,11 @@ import (
 	"time"
 )
 
-func GetObjectIdInStore(storeId string) (*string, error) {
+func ValidateStoreCodeAndGetObjectID(storeCode string) (primitive.ObjectID, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	filter := bson.M{
-		"store_code": storeId,
-	}
+	filter := bson.M{"store_code": storeCode}
 
 	var result struct {
 		ID primitive.ObjectID `bson:"_id"`
@@ -22,9 +20,8 @@ func GetObjectIdInStore(storeId string) (*string, error) {
 
 	err := mongodb.StoreColl.FindOne(ctx, filter).Decode(&result)
 	if err != nil {
-		return nil, err
+		return primitive.NilObjectID, err
 	}
 
-	objectIDStr := result.ID.Hex()
-	return &objectIDStr, nil
+	return result.ID, nil
 }

--- a/server/internal/pkg/database/structure/menu.go
+++ b/server/internal/pkg/database/structure/menu.go
@@ -10,6 +10,7 @@ type MOption struct {
 
 type MMenu struct {
 	ID               primitive.ObjectID `bson:"_id,omitempty" json:"ID"`
+	StoreID          primitive.ObjectID `bson:"store_id" json:"StoreID"`
 	StoreCode        string             `bson:"store_code" json:"StoreCode"`
 	Category         string             `bson:"category" json:"Category"`
 	Name             string             `bson:"name" json:"Name"`

--- a/server/internal/pkg/database/structure/order.go
+++ b/server/internal/pkg/database/structure/order.go
@@ -21,6 +21,7 @@ type MOrderItem struct {
 // 주문 전체
 type MOrder struct {
 	ID          primitive.ObjectID `bson:"_id,omitempty" json:"ID"`
+	StoreID     primitive.ObjectID `bson:"store_id" json:"StoreID"`
 	StoreCode   string             `bson:"store_code" json:"StoreCode"`
 	OrderNumber int32              `bson:"order_number" json:"OrderNumber"`
 	DineIn      bool               `bson:"dine_in" json:"DineIn"`

--- a/server/internal/pkg/grpc/inquiry.go
+++ b/server/internal/pkg/grpc/inquiry.go
@@ -6,7 +6,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	pb "server/gen"
-	mauth "server/internal/pkg/database/mongodb/auth"
+	mstore "server/internal/pkg/database/mongodb/store"
 	"server/internal/pkg/utils"
 	"sync"
 	"time"
@@ -66,11 +66,12 @@ loop:
 
 			once.Do(func() {
 				var err error
-				storeObjectID, err = mauth.GetObjectIdInStore(req.StoreCode)
+				objectID, err := mstore.ValidateStoreCodeAndGetObjectID(req.StoreCode)
 				if err != nil {
-					logrus.Error("failed to get store object ID: ", err)
-					panic(pb.EError_EE_API_FAILED)
+					panic(pb.EError_EE_STORE_NOT_FOUND)
 				}
+				str := objectID.Hex()
+				storeObjectID = &str
 			})
 
 			logrus.Infof("StreamInquiries received: store_code=%s, type=%s, data=%s", req.StoreCode, req.InquiryType, req.FrameData)

--- a/server/internal/pkg/grpc/menu.go
+++ b/server/internal/pkg/grpc/menu.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 	pb "server/gen"
 	mmenu "server/internal/pkg/database/mongodb/menu"
+	mstore "server/internal/pkg/database/mongodb/store"
 	dbstructure "server/internal/pkg/database/structure"
 	"server/internal/pkg/utils"
 )
@@ -22,7 +23,13 @@ func (s *Server) CreateMenu(ctx context.Context, req *pb.CreateMenuRequest) (res
 		}
 	}()
 
+	storeID, err := mstore.ValidateStoreCodeAndGetObjectID(req.StoreCode)
+	if err != nil {
+		panic(pb.EError_EE_STORE_NOT_FOUND)
+	}
+
 	mMenu := dbstructure.MMenu{
+		StoreID:          storeID,
 		StoreCode:        req.StoreCode,
 		Category:         req.Category,
 		Name:             req.Name,
@@ -34,7 +41,7 @@ func (s *Server) CreateMenu(ctx context.Context, req *pb.CreateMenuRequest) (res
 		Image:            req.Image,
 	}
 
-	err := mmenu.CreateMMenu(&mMenu)
+	err = mmenu.CreateMMenu(&mMenu)
 	if err != nil {
 		panic(fmt.Errorf("faild to create mMenu': %v", err))
 	}
@@ -56,10 +63,16 @@ func (s *Server) GetCategoryList(ctx context.Context, req *pb.GetCategoryListReq
 		}
 	}()
 
-	categories, err := mmenu.GetCategoryList(req.StoreCode)
+	storeID, err := mstore.ValidateStoreCodeAndGetObjectID(req.StoreCode)
+	if err != nil {
+		panic(pb.EError_EE_STORE_NOT_FOUND)
+	}
+
+	categories, err := mmenu.GetCategoryList(storeID)
 	if err != nil {
 		panic(fmt.Errorf("failed to get category list from mStore: %v", err))
 	}
+
 	return &pb.GetCategoryListResponse{
 		Success:    true,
 		Error:      nil,
@@ -77,7 +90,12 @@ func (s *Server) GetMenuList(ctx context.Context, req *pb.GetMenuListRequest) (r
 		}
 	}()
 
-	mMenus, err := mmenu.GetMMenuList(req.StoreCode, req.Category)
+	storeID, err := mstore.ValidateStoreCodeAndGetObjectID(req.StoreCode)
+	if err != nil {
+		panic(pb.EError_EE_STORE_NOT_FOUND)
+	}
+
+	mMenus, err := mmenu.GetMMenuList(storeID, req.Category)
 	if err != nil {
 		{
 			panic(fmt.Errorf("failed to get mMenu: %v", err))
@@ -110,7 +128,12 @@ func (s *Server) GetMenuDetail(ctx context.Context, req *pb.GetMenuDetailRequest
 		}
 	}()
 
-	mMenu, err := mmenu.GetMMenuDetail(req.StoreCode, req.Category, req.Name)
+	storeID, err := mstore.ValidateStoreCodeAndGetObjectID(req.StoreCode)
+	if err != nil {
+		panic(pb.EError_EE_STORE_NOT_FOUND)
+	}
+
+	mMenu, err := mmenu.GetMMenuDetail(storeID, req.Category, req.Name)
 	if err != nil {
 		panic(fmt.Errorf("failed to get mStore: %v", err))
 	}

--- a/server/internal/pkg/rest/menu.go
+++ b/server/internal/pkg/rest/menu.go
@@ -37,6 +37,11 @@ func (h *RestHandler) CreateMenu(c *gin.Context) {
 
 	grpcRes, err := authClient.CreateMenu(ctx, &req)
 	if err != nil {
+		logrus.Errorf("CreateMenu failed: %v", err)
+		//c.JSON(http.StatusBadRequest, gin.H{
+		//	"success": grpcRes.GetSuccess(),        // false
+		//	"error":   grpcRes.GetError().String(), // "EE_STORE_NOT_FOUND"
+		//})
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/server/proto/error.proto
+++ b/server/proto/error.proto
@@ -9,7 +9,7 @@ enum EError {
   EE_API_AUTH_FAILED = 10001;
 
   // store
-
+  EE_STORE_NOT_FOUND = 20001;
   // inquiry
   EE_INQUIRY_STREAM_FAILED = 30000;
 }


### PR DESCRIPTION
## 이슈
#62 
## 구현 내용
- server/internal/pkg/database/mongodb/store/validator.go : storeCode 검증 및 ObjectID 반환 함수 추가
- grpc/menu.go: store_code → objectID 유효성 검사 및 적용
- grpc/order.go: store_code 유효성 검사 적용
- menu.crud.go, order.crud.go : store_id 필터 적용
- proto/error.proto: EError_EE_STORE_NOT_FOUND 추가
- Postman 테스트 완료
- 추가로 DB에 저장되어있던 메뉴의 카테고리를 수정했습니다. (store_menu 참고)
