### PR TITLE
ai/refactor/deploy-ai-grpc-tls-1: 배포를 위한 TLS 도입한 grpc 서버 배포 완료

### DIFF
--- a/ai/Dockerfile
+++ b/ai/Dockerfile
@@ -4,7 +4,13 @@ WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install --upgrade pip
+
+# torch CPU 버전 따로 설치
+RUN pip install torch==2.1.0+cpu torchvision==0.16.0+cpu torchaudio==2.1.0 \
+    -f https://download.pytorch.org/whl/cpu/torch_stable.html
+
 RUN pip install --no-cache-dir --upgrade --no-deps -r requirements.txt
+
 RUN apt-get update && apt-get install -y libgl1
 
 COPY . .

--- a/ai/grpc/all_predict_sign_server.py
+++ b/ai/grpc/all_predict_sign_server.py
@@ -191,9 +191,11 @@ def load_tls_credentials():
     with open('certs/server.key', 'rb') as f:
         private_key = f.read()
 
-    return grpc.ssl_server_credentials([(private_key, certificate_chain)])
-
-
+    return grpc.ssl_server_credentials(
+        [(private_key, certificate_chain)],
+        root_certificates=None,
+        require_client_auth=False
+    )
 
 def serve():
     try:
@@ -209,7 +211,7 @@ def serve():
         port_result = server.add_secure_port('[::]:50051', creds)
         print(f"✅ 포트 바인딩 결과: {port_result}")
         
-        print("🚀 AI 서버 실행 중... 포트: 443")
+        print("🚀 AI 서버 실행 중... 포트: 50051")
         server.start()
         server.wait_for_termination()
     except Exception as e:

--- a/ai/requirements.txt
+++ b/ai/requirements.txt
@@ -128,8 +128,6 @@ tf_keras==2.19.0
 threadpoolctl==3.6.0
 tiktoken==0.9.0
 tokenizers==0.13.3
-torch==2.6.0
-torchvision==0.21.0
 tqdm==4.67.1
 transformers==4.33.3
 typing-inspect==0.9.0


### PR DESCRIPTION
### 개요

- 테스트를 위한 tls credentials과 .env는 슬랙의 .env 컨버스를 참고 부탁드립니다
- AI의 grpc 서버 포트 번호는 `50051` 입니다!!
- TLS 를 생성할 때 필수 조건 : keyUsage = digitalSignature, keyEncipherment extendedKeyUsage = serverAuth
명시해 certs_config.cnf 생성해 Ec2 & 테스트를 위한 로컬에 동일한 credentials 마운트
- 배포에서는 버전 충돌났던 사항들 적용 완료

---
#### 클라이언트 측 처리 요청 사항 (한국수어 -> 한국어)

- certs 로드 
- grpc 연결 시도 (요청 시에 100MB 전송 가능하도록)
- 세부사항 1 : all_predict_sign_pb2_grpc.SignAIStub(channel)
- 세부사항 2 : grpc 전송 시에 frames, fpx, video_length 정보를 client_id와 함께 보내주도록

(참고)
```
with open("certs/server.crt", "rb") as f:
        trusted_certs = f.read()
credentials = grpc.ssl_channel_credentials(root_certificates=trusted_certs)

channel = grpc.secure_channel(f"{host}:50051",
                              credentials,
                                  options=[('grpc.max_send_message_length', 10 * 1024 * 1024 * 10),  # 100MB
                                           ('grpc.max_receive_message_length', 10 * 1024 * 1024 * 10)])  # 100MB
stub = all_predict_sign_pb2_grpc.SignAIStub(channel)
```

---

> 예상 시나리오

프론트엔드
- 웹켐으로 수어 문의하기 영상 가져오기
- 프레임 단위로 영상 끊어서 jpg 형태로 저장하기

(참고)
```
success, buffer = cv2.imencode('.jpg', frame)
    if success:
        frame_bytes = buffer.tobytes()
        frames.append(frame_bytes)
```
- 영상의 속도 (fps), 영상의 길이 정보 가져오기

(참고)
```
fps = cap.get(cv2.CAP_PROP_FPS)
frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
video_length = frame_count / fps
```

백엔드 
- jpg 들을 한 배열에 묶어줌
- 영상의 속도, 영상의 길이와 함께 AI 서버로 전송

(참고)
```
request = all_predict_sign_pb2.FrameSequenceInput(
    frames=frames,
    client_id="client_01",
    fps=fps,
    video_length=video_length
)


response = stub.PredictFromFrames(request)
```

---
#### 클라이언트 측 처리 요청 사항 (한국어 -> 한국수어)

- certs 로드 
- grpc 연결 시도 (요청 시에 100MB 전송 가능하도록)
- 세부사항 1 : all_predict_sign_pb2_grpc.SignAIStub(channel)
- 세부사항 2 : grpc 전송 시에 message를 client_id와 함께 보내주도록

(참고)
```
with open("certs/server.crt", "rb") as f:
    trusted_certs = f.read()

    credentials = grpc.ssl_channel_credentials(root_certificates=trusted_certs)
    channel = grpc.secure_channel(f"{host}:50051", credentials)
    # channel = grpc.secure_channel(f"localhost:50051", credentials)
    stub = all_predict_sign_pb2_grpc.SignAIStub(channel)
```

---
> 예상 시나리오 

백엔드
- 변환할 한국어 입력값 받아 AI 서버로 전송

(참고)
```
    request = all_predict_sign_pb2.KoreanInput(
        message="현재 카페 자리가 없어요",
        client_id="client_01"
    )
```