### PR TITLE
ai/refactor/proto-change-send-method-1: 프론트엔드, 백엔드의 스트리밍 형식의 프레임 전송 방식에서 AI 서버의 부담을 줄이기 위한 미디어 파이프 프론트 엔드로 이월

### DIFF
--- a/ai/Dockerfile
+++ b/ai/Dockerfile
@@ -6,7 +6,7 @@ COPY requirements.txt .
 RUN pip install --upgrade pip
 
 # torch CPU 버전 따로 설치
-RUN pip install torch==2.1.0+cpu torchvision==0.16.0+cpu torchaudio==2.1.0 \
+RUN pip install torch==2.1.0 torchvision==0.16.0 torchaudio==2.1.0 \
     -f https://download.pytorch.org/whl/cpu/torch_stable.html
 
 RUN pip install --no-cache-dir --upgrade --no-deps -r requirements.txt

--- a/ai/grpc/all_predict_sign_pb2.py
+++ b/ai/grpc/all_predict_sign_pb2.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16\x61ll_predict_sign.proto\x12\x07predict\"Z\n\x12\x46rameSequenceInput\x12\x0e\n\x06\x66rames\x18\x01 \x03(\x0c\x12\x11\n\tclient_id\x18\x02 \x01(\t\x12\x0b\n\x03\x66ps\x18\x03 \x01(\x02\x12\x14\n\x0cvideo_length\x18\x04 \x01(\x02\"R\n\rPredictResult\x12\x11\n\tclient_id\x18\x01 \x01(\t\x12\x1a\n\x12predicted_sentence\x18\x02 \x01(\t\x12\x12\n\nconfidence\x18\x03 \x01(\x02\"1\n\x0bKoreanInput\x12\x0f\n\x07message\x18\x01 \x01(\t\x12\x11\n\tclient_id\x18\x02 \x01(\t\"0\n\rSignUrlResult\x12\x11\n\tclient_id\x18\x01 \x01(\t\x12\x0c\n\x04urls\x18\x02 \x03(\t2\x9d\x01\n\x06SignAI\x12H\n\x11PredictFromFrames\x12\x1b.predict.FrameSequenceInput\x1a\x16.predict.PredictResult\x12I\n\x19TranslateKoreanToSignUrls\x12\x14.predict.KoreanInput\x1a\x16.predict.SignUrlResultb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16\x61ll_predict_sign.proto\x12\x07predict\"Y\n\x12\x46rameSequenceInput\x12\x0e\n\x06\x66rames\x18\x01 \x03(\x02\x12\x10\n\x08store_id\x18\x02 \x01(\t\x12\x0b\n\x03\x66ps\x18\x03 \x01(\x05\x12\x14\n\x0cvideo_length\x18\x04 \x01(\x05\"Q\n\rPredictResult\x12\x10\n\x08store_id\x18\x01 \x01(\t\x12\x1a\n\x12predicted_sentence\x18\x02 \x01(\t\x12\x12\n\nconfidence\x18\x03 \x01(\x02\"0\n\x0bKoreanInput\x12\x0f\n\x07message\x18\x01 \x01(\t\x12\x10\n\x08store_id\x18\x02 \x01(\t\"/\n\rSignUrlResult\x12\x10\n\x08store_id\x18\x01 \x01(\t\x12\x0c\n\x04urls\x18\x02 \x03(\t2\x9d\x01\n\x06SignAI\x12H\n\x11PredictFromFrames\x12\x1b.predict.FrameSequenceInput\x1a\x16.predict.PredictResult\x12I\n\x19TranslateKoreanToSignUrls\x12\x14.predict.KoreanInput\x1a\x16.predict.SignUrlResultb\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'all_predict_sign_pb2', globals())
@@ -21,13 +21,13 @@ if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
   _FRAMESEQUENCEINPUT._serialized_start=35
-  _FRAMESEQUENCEINPUT._serialized_end=125
-  _PREDICTRESULT._serialized_start=127
-  _PREDICTRESULT._serialized_end=209
-  _KOREANINPUT._serialized_start=211
-  _KOREANINPUT._serialized_end=260
-  _SIGNURLRESULT._serialized_start=262
-  _SIGNURLRESULT._serialized_end=310
-  _SIGNAI._serialized_start=313
-  _SIGNAI._serialized_end=470
+  _FRAMESEQUENCEINPUT._serialized_end=124
+  _PREDICTRESULT._serialized_start=126
+  _PREDICTRESULT._serialized_end=207
+  _KOREANINPUT._serialized_start=209
+  _KOREANINPUT._serialized_end=257
+  _SIGNURLRESULT._serialized_start=259
+  _SIGNURLRESULT._serialized_end=306
+  _SIGNAI._serialized_start=309
+  _SIGNAI._serialized_end=466
 # @@protoc_insertion_point(module_scope)

--- a/ai/grpc/proto/all_predict_sign.proto
+++ b/ai/grpc/proto/all_predict_sign.proto
@@ -3,25 +3,25 @@ syntax = "proto3";
 package predict;
 
 message FrameSequenceInput {
-    repeated bytes frames = 1;
-    string client_id = 2;
-    float fps = 3;
-    float video_length = 4;
+    repeated float frames = 1;
+    string store_id = 2;
+    int32 fps = 3;
+    int32 video_length = 4;
 }
 
 message PredictResult {
-    string client_id = 1;
+    string store_id = 1;
     string predicted_sentence = 2;
     float confidence = 3; 
 }
 
 message KoreanInput {
     string message = 1;
-    string client_id = 2;
+    string store_id = 2;
 }
 
 message SignUrlResult {
-    string client_id = 1;
+    string store_id = 1;
     repeated string urls = 2;
 }
 


### PR DESCRIPTION


- 이전의 스트리밍 방식에서는 많은 용량을 차지해야 했기 때문에 grpc의 용량 제한을 100MB로 했는데 해당 경우에는 30초 영상의 경우 1MB정도를 차지 하기 때문에 용량 제한을 10MB로 다운그레이드 함

- 외에 angle 78개를 받고 정확도가 낮을 경우 앞 프레임의 angle 정보로 재예측을 하는 로직은 동일함