### PR TITLE
Server/feat/korean text send

### DIFF
--- a/server/cmd/myapp/main.go
+++ b/server/cmd/myapp/main.go
@@ -1,14 +1,16 @@
 package main
 
 import (
-	"github.com/joho/godotenv"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"server/internal/pkg/database/mongodb"
 	grpcHandler "server/internal/pkg/grpc"
 	"server/internal/pkg/rest"
-	"server/internal/pkg/websocket"
+	"server/internal/pkg/utils"
+	websocketHandler "server/internal/pkg/websocket"
+
+	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
@@ -23,6 +25,11 @@ func initialize() {
 			logrus.Println("Recovered from panic during initialization:", r)
 		}
 	}()
+
+	// AI 클라이언트 초기화
+	if err := utils.InitializeAIClient(); err != nil {
+		logrus.Fatalf("Failed to initialize AI client: %v", err)
+	}
 
 	mongodb.Initialize()
 	go func() {

--- a/server/internal/pkg/grpc/inquiry.go
+++ b/server/internal/pkg/grpc/inquiry.go
@@ -110,7 +110,7 @@ loop:
 	logrus.Infof("total received: %d", totalReceived)
 
 	// 축적한 데이터 ai 로 전송
-	predictResp, err := s.AiClient.PredictFromFrames(stream.Context(), &pb.FrameSequenceInput{
+	predictResp, err := utils.AiClient.PredictFromFrames(stream.Context(), &pb.FrameSequenceInput{
 		Frames:  sequence,
 		StoreId: storeObjectID.Hex(),
 		Fps:     30,
@@ -164,7 +164,7 @@ loop:
 		}
 
 		for attempt := 1; attempt <= maxRetries; attempt++ {
-			if err := websocketHandler.SendMessageToClient(storeCode, message); err != nil {
+			if err := websocketHandler.SendMessageToClient(storeCode, message, utils.WebSocketClientTypeManagerWeb); err != nil {
 				logrus.Warnf("Websocket send attempt %d failed: %v", attempt, err)
 
 				if attempt == maxRetries {

--- a/server/internal/pkg/utils/aiinitialize.go
+++ b/server/internal/pkg/utils/aiinitialize.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"os"
+	pb "server/gen"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+var (
+	AiClient pb.SignAIClient
+)
+
+func InitializeAIClient() error {
+	aiHost := os.Getenv("AI_GRPC_HOST")
+	if aiHost == "" {
+		logrus.Errorln("AI_GRPC_HOST is not set")
+		return fmt.Errorf("AI_GRPC_HOST is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	creds, err := createTLSCredentialsFromEnv()
+	if err != nil {
+		return fmt.Errorf("failed to create TLS credentials: %v", err)
+	}
+
+	conn, err := grpc.DialContext(ctx, aiHost, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return fmt.Errorf("failed to connect to AI gRPC server: %v", err)
+	}
+
+	AiClient = pb.NewSignAIClient(conn)
+	logrus.Infof("AI Server Connect Success")
+	return nil
+}
+
+func createTLSCredentialsFromEnv() (credentials.TransportCredentials, error) {
+	b64Cert := os.Getenv("AI_TLS_CRT_SERVER")
+	if b64Cert == "" {
+		return nil, fmt.Errorf("AI_TLS_CRT_SERVER is not set")
+	}
+
+	certPEM, err := base64.StdEncoding.DecodeString(b64Cert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode base64: %v", err)
+	}
+
+	caCertPool := x509.NewCertPool()
+	if ok := caCertPool.AppendCertsFromPEM(certPEM); !ok {
+		return nil, fmt.Errorf("failed to append CA certificate")
+	}
+
+	creds := credentials.NewTLS(&tls.Config{
+		RootCAs: caCertPool,
+	})
+	return creds, nil
+}

--- a/server/internal/pkg/utils/struct.go
+++ b/server/internal/pkg/utils/struct.go
@@ -25,3 +25,9 @@ const (
 	StreamDataTypeOrder   = "order"
 	StreamDataTypeInquiry = "inquiry"
 )
+
+// WebSocket Client Types
+const (
+	WebSocketClientTypeCounterApp = "counter_app"
+	WebSocketClientTypeManagerWeb = "manager_web"
+)

--- a/server/internal/pkg/websocket/handler.go
+++ b/server/internal/pkg/websocket/handler.go
@@ -29,7 +29,7 @@ var (
 func WebSocketHandler(w http.ResponseWriter, r *http.Request) {
 	// 0. api key ckeck & Authorization
 	// 0.1 api key check
-	apiKey := r.Header.Get("api-key")
+	apiKey := r.URL.Query().Get("api-key")
 
 	if apiKey != os.Getenv("WEBSOCKET_API_KEY") {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)

--- a/server/internal/pkg/websocket/handler.go
+++ b/server/internal/pkg/websocket/handler.go
@@ -1,6 +1,7 @@
 package websocketHandler
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -89,5 +90,26 @@ func WebSocketHandler(w http.ResponseWriter, r *http.Request) {
 		// 메세지 처리
 		// go func 으로 메세지 db에 저장하는 로직 넣기
 		// 테스트 커밋
+		// 메시지 파싱
+		var wsMsg WebSocketReceiveMessage
+		if err := json.Unmarshal(msg, &wsMsg); err != nil {
+			logrus.Errorf("Message unmarshal error: %v", err)
+			continue
+		}
+
+		// 메시지 저장
+		if err := ReceiveKoreanMessage(&wsMsg); err != nil {
+			logrus.Errorf("Failed to process message: %v", err)
+			// 에러 응답을 클라이언트에게 전송
+			conn.WriteJSON(map[string]string{
+				"error": err.Error(),
+			})
+			continue
+		}
+
+		// 성공 응답
+		conn.WriteJSON(map[string]string{
+			"status": "success",
+		})
 	}
 }

--- a/server/internal/pkg/websocket/receivemessage.go
+++ b/server/internal/pkg/websocket/receivemessage.go
@@ -1,0 +1,102 @@
+package websocketHandler
+
+import (
+	"context"
+	"time"
+
+	pb "server/gen"
+	mmessage "server/internal/pkg/database/mongodb/message"
+	mstore "server/internal/pkg/database/mongodb/store"
+	dbstructure "server/internal/pkg/database/structure"
+	"server/internal/pkg/utils"
+
+	"github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type WebSocketReceiveMessage struct {
+	Title     string `json:"title"`
+	Number    int    `json:"number"`
+	Message   string `json:"message"`
+	StoreCode string `json:"store_code"`
+}
+
+func ReceiveKoreanMessage(msg *WebSocketReceiveMessage) error {
+	// 1. AI 서버에 한국어 메시지 전송하여 수화 URL 받기
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// store_code를 store_id로 변환
+	storeObjectID, err := mstore.ValidateStoreCodeAndGetObjectID(msg.StoreCode)
+	if err != nil {
+		logrus.Errorf("Store validation failed: %v", err)
+		return err
+	}
+
+	// title & number notification coll 에 조회
+	_, err = mmessage.GetNotificationMessage(&storeObjectID, msg.Title, msg.Number)
+	if err != nil {
+		logrus.Errorf("Failed to get notification: %v", err)
+		return err
+	}
+
+	// AI 서버에 요청
+	signUrlsResp, err := utils.AiClient.TranslateKoreanToSignUrls(ctx, &pb.KoreanInput{
+		Message: msg.Message,
+		StoreId: storeObjectID.Hex(),
+	})
+	if err != nil {
+		logrus.Errorf("Failed to get sign URLs from AI server: %v", err)
+		return err
+	}
+
+	// 2. 메시지 저장
+	mMessage := dbstructure.MMessage{
+		ID:        primitive.NewObjectID(),
+		StoreId:   storeObjectID,
+		Title:     msg.Title,
+		Number:    int32(msg.Number),
+		CreatedAt: time.Now(),
+		Message:   msg.Message,
+		IsOwner:   true,
+	}
+
+	err = mmessage.CreateMMessage(&mMessage)
+	if err != nil {
+		logrus.Errorf("Failed to save message: %v", err)
+		return err
+	}
+
+	// 3. 웹소켓으로 수화 URL 전송
+	message := WebSocketMessage{
+		Type: "signMessage",
+		Data: SignUrlData{
+			SignUrls: signUrlsResp.Urls,
+		},
+	}
+
+	// 웹소켓으로 메시지 전송
+	go func() {
+		maxRetries := 3
+		backoff := time.Second
+
+		for attempt := 1; attempt <= maxRetries; attempt++ {
+			if err := SendMessageToClient(msg.StoreCode, message, utils.WebSocketClientTypeCounterApp); err != nil {
+				logrus.Warnf("Websocket send attempt %d failed: %v", attempt, err)
+
+				if attempt == maxRetries {
+					logrus.Errorf("Failed to send websocket notification after %d attempts: %v", maxRetries, err)
+					return
+				}
+
+				time.Sleep(backoff)
+				backoff *= 2
+			} else {
+				return
+			}
+		}
+	}()
+
+	logrus.Infof("Message saved and sign URLs sent successfully: %s (Order #%d)", msg.Title, msg.Number)
+	return nil
+}

--- a/server/internal/pkg/websocket/sendmessage.go
+++ b/server/internal/pkg/websocket/sendmessage.go
@@ -8,13 +8,15 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-func SendMessageToClient(store_code string, message WebSocketMessage) error {
+func SendMessageToClient(store_code string, message WebSocketMessage, client_type string) error {
+	connectionName := fmt.Sprintf("%s_%s", store_code, client_type)
+
 	WebSocketClientsMutex.RLock()
-	conn, ok := WebSocketClients[store_code]
+	conn, ok := WebSocketClients[connectionName]
 	WebSocketClientsMutex.RUnlock()
 
 	if !ok {
-		return fmt.Errorf("client not found: %s", store_code)
+		return fmt.Errorf("client not found: %s", connectionName)
 	}
 
 	messageJSON, err := json.Marshal(message)
@@ -26,7 +28,7 @@ func SendMessageToClient(store_code string, message WebSocketMessage) error {
 }
 
 type WebSocketMessage struct {
-	Type string      `json:"type"` //notification, orderMessage, inquiryMessage
+	Type string      `json:"type"` //notification, orderMessage, inquiryMessage, signMessage
 	Data interface{} `json:"data"`
 }
 
@@ -39,4 +41,8 @@ type MessageData struct {
 	Num       int32     `json:"num"`
 	Message   string    `json:"message"`
 	CreatedAt time.Time `json:"created_at"`
+}
+
+type SignUrlData struct {
+	SignUrls []string `json:"sign_urls"`
 }


### PR DESCRIPTION
## 연관된 이슈
#114 

## 요약
* 관리자 웹에서 한국어 텍스트 전송 -> 카운터 앱에 수어 영상 출력 기능 구현 
* store_code 하나로 카운터 앱 / 관리자 웹 같은 웹소켓 접속해 사용 
  쿼리로 client_type 입력받아 다른 웹소켓에 접속하게 수정
* grpc client 인 AIClient 설정 uitl 로 이동
* 테스트


# 상세 
웹소켓 관련 설명 노션 (api 명세서) 참조