### PR TITLE
Server/feat/get chatroom list 2

### DIFF
--- a/server/internal/pkg/database/mongodb/order/crud.go
+++ b/server/internal/pkg/database/mongodb/order/crud.go
@@ -149,7 +149,7 @@ func UpdateMOrderStatus(storeID primitive.ObjectID, orderNumber int32, newStatus
 	return err
 }
 
-func UpdateMOrderStatusAndMNotificationAccepted(storeID primitive.ObjectID, orderNumber int32, newStatus pb.OrderStatus, accepted bool) error {
+func UpdateMOrderStatusAndMNotificationFinished(storeID primitive.ObjectID, orderNumber int32, newStatus pb.OrderStatus, finished bool) error {
 	session, err := mongodb.Client.StartSession()
 	if err != nil {
 		return err
@@ -181,7 +181,7 @@ func UpdateMOrderStatusAndMNotificationAccepted(storeID primitive.ObjectID, orde
 		}
 		notificationUpdate := bson.M{
 			"$set": bson.M{
-				"accepted":   accepted,
+				"finished":   finished,
 				"updated_at": update_at,
 			},
 		}

--- a/server/internal/pkg/database/structure/message.go
+++ b/server/internal/pkg/database/structure/message.go
@@ -11,7 +11,8 @@ type MNotificationMessage struct {
 	StoreCode         primitive.ObjectID `bson:"store_code"` // 가게 obejct id
 	NotificationTitle string             `bson:"title"`      // order, inquiry
 	Number            int                `bson:"number"`     // 주문번호나 문의번호
-	Accepted          bool               `bson:"accepted"`   // 처리 여부, true : 처리 완료(완료), false : 처리 미완료(이전)
+	Accepted          bool               `bson:"accepted"`   // 확인 여부, true : 주문 번호 입력 , false : 주문 번호 입력 전, 주문 등록만 하고 번호 입력으로 가져오기 안함
+	Finished          bool               `bson:"finished"`   // 처리 여부, true : 주문 처리 완료 -> 완료, false : 주문 처리 이전 -> 이전
 	Deleted           bool               `bson:"deleted"`    // 삭제 여부, true : 삭제, false : 미삭제
 	CreatedAt         time.Time          `bson:"created_at"` // 메세지 생성 시간
 	UpdatedAt         time.Time          `bson:"updated_at"` // cron 으로 삭제하기 위한 updated_at -> deleted 로 바뀌면 시간 업데이트

--- a/server/internal/pkg/grpc/message.go
+++ b/server/internal/pkg/grpc/message.go
@@ -48,6 +48,12 @@ func (s *Server) GetMessages(
 		panic(err)
 	}
 
+	// notification accepted 변경
+	err = mmessage.UpdateMNotificationAccepted(&storeId, req.NotificationTitle, req.Number, true)
+	if err != nil {
+		panic(err)
+	}
+
 	// 메세지 MMessage -> pb.Message 로 변환
 	pbMessages := make([]*pb.Message, len(mMessages))
 	for i, mMessage := range mMessages {

--- a/server/internal/pkg/grpc/order.go
+++ b/server/internal/pkg/grpc/order.go
@@ -72,6 +72,7 @@ func (s *Server) CreateOrder(ctx context.Context, req *pb.CreateOrderRequest) (r
 		StoreCode:         storeID,
 		NotificationTitle: utils.NotificationTitleOrder,
 		Accepted:          false,
+		Finished:          false,
 		Deleted:           false,
 		CreatedAt:         createTime,
 		UpdatedAt:         createTime,
@@ -246,7 +247,7 @@ func (s *Server) UpdateOrderStatus(ctx context.Context, req *pb.UpdateOrderStatu
 		panic(pb.EError_EE_NOTIFICATION_NOT_FOUND)
 	}
 
-	err = morder.UpdateMOrderStatusAndMNotificationAccepted(storeID, req.OrderNumber, req.Status, true)
+	err = morder.UpdateMOrderStatusAndMNotificationFinished(storeID, req.OrderNumber, req.Status, true)
 	if err != nil {
 		logrus.Errorf("[gRPC UpdateOrderStatus] Failed to update order status and notification accepted")
 		panic(pb.EError_EE_DB_OPERATION_FAILED)

--- a/server/internal/pkg/rest/message.go
+++ b/server/internal/pkg/rest/message.go
@@ -51,9 +51,6 @@ func (h *RestHandler) GetMessages(c *gin.Context) {
 	}
 
 	var req pb.GetMessagesRequest
-	if !BindJSONOrError(c, &req) {
-		return
-	}
 
 	req.StoreCode = storeCode
 


### PR DESCRIPTION
## 연관된 이슈
#126 

## 요약
* notification coll 에 finished filed 추가
* 관리자 웹 주문 번호 입력 시 accepted filed 가 변하게 수정
* 주문 제조 완료 시 finished filed 가 변하게 수정
* 대화창(알림) 리스트 검색 시 기준(field) 변경


## 상세 
* 테스트 
1. 새로운 주문 생성
![image](https://github.com/user-attachments/assets/d38c9b4f-5b2a-498c-9805-72ed90f63f2c)

2. 대화창(채팅방, 알림) 리스트 확인
![image](https://github.com/user-attachments/assets/14b2f7e1-d57f-4e00-898c-69782a03198a)
![image](https://github.com/user-attachments/assets/adf76b28-af52-42c5-b751-a5809384f4e4)
이전, 완료 리스트에 아무것도 없음

3. 주문번호 입력으로 대화창 접속(GetMessages)
![image](https://github.com/user-attachments/assets/8542db2a-a213-4469-9e91-f6ed86ff5c4e)

4.  주문 등록 후. 대화창(채팅방,알림) 리스트 확인
![image](https://github.com/user-attachments/assets/9f85d963-df62-4a13-90ea-922a25db689d)
이전 리스트에서 확인 가능

5. 주문 처리 완료(UpdateOrderStatus) 
![image](https://github.com/user-attachments/assets/b6f30d05-3590-4dac-8cba-9772ff68a412)

6. 주문 처리 완료 후. 대화창(채팅방,알림) 리스트 확인
![image](https://github.com/user-attachments/assets/9d11bea5-6918-4eb3-8272-af7593eb24ad)

