### PR TITLE
Server/fix/order 주문 생성 시 메뉴 존재 여부 검증, DineIn JSON Binding 오류 수정

### DIFF
--- a/server/internal/pkg/grpc/order.go
+++ b/server/internal/pkg/grpc/order.go
@@ -37,9 +37,18 @@ func (s *Server) CreateOrder(ctx context.Context, req *pb.CreateOrderRequest) (r
 	var items []dbstructure.MOrderItem
 	for _, item := range req.Items {
 
+		exists, err := mmenu.IsMenuExists(storeID, item.Name)
+		if err != nil {
+			logrus.Errorf("[gRPC CreateOrder] Failed to search a menu for %s", item.Name)
+			panic(pb.EError_EE_DB_OPERATION_FAILED)
+		}
+		if !exists {
+			logrus.Errorf("[gRPC CreateOrder] Menu not found for %s", item.Name)
+			panic(pb.EError_EE_MENU_NOT_FOUND)
+		}
 		image, err := mmenu.FindMenuImage(storeID, item.Name)
 		if err != nil {
-			logrus.Warnf("Image not found for %s: %v", item.Name, err)
+			logrus.Errorf("[gRPC CreateOrder] Image not found for %s: %v", item.Name, err)
 			image = ""
 		}
 

--- a/server/internal/pkg/rest/order.go
+++ b/server/internal/pkg/rest/order.go
@@ -33,7 +33,7 @@ func (h *RestHandler) CreateOrder(c *gin.Context) {
 	}
 
 	type CreateOrderBody struct {
-		DineIn     bool            `json:"dine_in" binding:"required"`
+		DineIn     *bool           `json:"dine_in" binding:"required"`
 		Items      []*pb.OrderItem `json:"items" binding:"required"`
 		TotalPrice int32           `json:"total_price" binding:"required"`
 	}
@@ -61,7 +61,7 @@ func (h *RestHandler) CreateOrder(c *gin.Context) {
 
 	grpcReq := &pb.CreateOrderRequest{
 		StoreCode:  storeCode,
-		DineIn:     req.DineIn,
+		DineIn:     *req.DineIn,
 		Items:      req.Items,
 		TotalPrice: req.TotalPrice,
 	}


### PR DESCRIPTION
## 이슈
#140 

## 작업 내용
1. 메뉴 존재 여부 검증 
- 주문 생성 시 menu DB에 존재하지 않는 메뉴 이름이 포함되면 EE_INVALID_ARGUMENT 에러를 반환
- 잘못된 메뉴 이름으로도 주문이 생성되던 문제를 해결

2. DineIn JSON 바인딩 오류 해결
- Go에서 bool 타입은 기본값이 false임
- 즉, JSON 바디에 "dine_in": false가 존재하더라도, binding:"required"는 이를 "값이 없다고" 판단할 수 있어 오류 발생
- bool 타입이 false일 경우 binding:"required"로는 검증이 되지 않던 문제 해결

## 테스트
- 존재하지 않는 메뉴 → 주문 요청 시 400 에러 + 에러 메시지 반환 확인
<img width="717" alt="스크린샷 2025-05-09 오후 11 57 37" src="https://github.com/user-attachments/assets/e9bac845-b992-443c-99a2-a73423207325" />
- dine_in 필드 누락 → JSON Binding 실패
<img width="721" alt="스크린샷 2025-05-09 오후 11 58 04" src="https://github.com/user-attachments/assets/062f149d-d5cb-4fd8-a074-e2f92e2b17b2" />

