### PR TITLE
Server/feat/fast inquiry key world add

### DIFF
--- a/server/internal/pkg/database/mongodb/collections.go
+++ b/server/internal/pkg/database/mongodb/collections.go
@@ -10,6 +10,7 @@ var (
 	CounterColl      = &mongo.Collection{}
 	NotificationColl = &mongo.Collection{}
 	MessageColl      = &mongo.Collection{}
+	FastInquiryColl  = &mongo.Collection{}
 )
 
 func defineCollections() {
@@ -20,4 +21,5 @@ func defineCollections() {
 	CounterColl = Client.Database(name).Collection("order_counter")
 	NotificationColl = Client.Database(name).Collection("notification")
 	MessageColl = Client.Database(name).Collection("message")
+	FastInquiryColl = Client.Database(name).Collection("fast_inquiry")
 }

--- a/server/internal/pkg/database/mongodb/fastinquiry/crud.go
+++ b/server/internal/pkg/database/mongodb/fastinquiry/crud.go
@@ -1,0 +1,20 @@
+package mfastinquiry
+
+import (
+	"context"
+	"server/internal/pkg/database/mongodb"
+	dbstructure "server/internal/pkg/database/structure"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func GetFastInquiry(name string) (*dbstructure.FastInquiry, error) {
+	filter := bson.M{"name": name}
+
+	var fastInquiry dbstructure.FastInquiry
+	err := mongodb.FastInquiryColl.FindOne(context.Background(), filter).Decode(&fastInquiry)
+	if err != nil {
+		return nil, err
+	}
+	return &fastInquiry, nil
+}

--- a/server/internal/pkg/database/structure/fastinquiry.go
+++ b/server/internal/pkg/database/structure/fastinquiry.go
@@ -1,0 +1,10 @@
+package dbstructure
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+type FastInquiry struct {
+	ID        primitive.ObjectID `bson:"_id,omitempty" json:"ID"`
+	Name      string             `bson:"name" json:"Name"`
+	InquiryNo int32              `bson:"inquiry_no" json:"InquiryNo"`
+	URLs      []string           `bson:"urls" json:"URLs"`
+}


### PR DESCRIPTION
## 요약
* 관리자 웹에서 메세지 전송 시 네/아니요/잠시만 기다려주세요/결제해드릴게요 등 빠른 응답 ai 서버까지 가지 않고 빠르게 db에서 가져와서 프런트로 반환하는 기능 추가 


## 상세 
![image](https://github.com/user-attachments/assets/92a573a5-b35f-49ab-b823-e206094e445f)
<관리자 웹 웹소켓 상황>

관리자 웹 메세지 형식
{
    "title": "orderMessage", 
    "number": 101, 
    "message": "결제해드릴게요",
    "store_code": "5fjVwE8z"
}

![image](https://github.com/user-attachments/assets/ae556cc2-c8c7-4ae7-b09d-c66b3b7bc0f7)
<카운터 앱 웹소켓 상황>

카운터 앱 웹소켓 응답 메세지 형식
{
    "type": "signMessage",
    "data": {
        "sign_urls": [
            "https://signorderavatarvideo.s3.ap-northeast-2.amazonaws.com/%E1%84%80%E1%85%A7%E1%86%AF%E1%84%8C%E1%85%A6.mp4",
            "https://signorderavatarvideo.s3.ap-northeast-2.amazonaws.com/%E1%84%83%E1%85%B3%E1%84%85%E1%85%B5%E1%84%83%E1%85%A1.mp4"
        ]
    }
}