### PR TITLE
Server/feat : GetMenuDetail 응답 형식에 description 필드 추가

### DIFF
--- a/proto/menu.proto
+++ b/proto/menu.proto
@@ -21,9 +21,10 @@ message ViewMenuDetail{
   string category = 1;
   string name = 2;
   int32 menu_price = 3;
-  string image = 4;
-  repeated string sign_language_urls = 5;
-  repeated Option options = 6;
+  string description = 4;
+  string image = 5;
+  repeated string sign_language_urls = 6;
+  repeated Option options = 7;
 }
 
 message CreateMenuRequest {

--- a/server/gen/error.pb.go
+++ b/server/gen/error.pb.go
@@ -122,7 +122,7 @@ var File_error_proto protoreflect.FileDescriptor
 
 const file_error_proto_rawDesc = "" +
 	"\n" +
-	"\verror.proto*\xe9\x03\n" +
+	"\verror.proto*\x95\x04\n" +
 	"\x06EError\x12\x12\n" +
 	"\x0eEE_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\rEE_API_FAILED\x10\x90N\x12\x17\n" +
@@ -132,7 +132,8 @@ const file_error_proto_rawDesc = "" +
 	"\x17EE_STORE_ALREADY_EXISTS\x10\xa0\x9c\x01\x12\x18\n" +
 	"\x12EE_STORE_NOT_FOUND\x10\xa1\x9c\x01\x12\x1f\n" +
 	"\x19EE_STORE_UPDATE_NO_FIELDS\x10\xa2\x9c\x01\x12\x1e\n" +
-	"\x18EE_INQUIRY_STREAM_FAILED\x10\xb0\xea\x01\x129\n" +
+	"\x18EE_INQUIRY_STREAM_FAILED\x10\xb0\xea\x01\x12*\n" +
+	"$EE_AI_CONVERSION_CONFIDENCE_IS_WRONG\x10\xb1\xea\x01\x129\n" +
 	"3EE_ORDER_AND_NOTIFICATION_AND_MESSAGE_DB_ADD_FAILED\x10\xc0\xb8\x02\x12\x18\n" +
 	"\x12EE_ORDER_NOT_FOUND\x10\xc1\xb8\x02\x12\x1c\n" +
 	"\x16EE_MENU_ALREADY_EXISTS\x10І\x03\x12\x17\n" +

--- a/server/gen/menu.pb.go
+++ b/server/gen/menu.pb.go
@@ -154,9 +154,10 @@ type ViewMenuDetail struct {
 	Category         string                 `protobuf:"bytes,1,opt,name=category,proto3" json:"category,omitempty"`
 	Name             string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	MenuPrice        int32                  `protobuf:"varint,3,opt,name=menu_price,json=menuPrice,proto3" json:"menu_price,omitempty"`
-	Image            string                 `protobuf:"bytes,4,opt,name=image,proto3" json:"image,omitempty"`
-	SignLanguageUrls []string               `protobuf:"bytes,5,rep,name=sign_language_urls,json=signLanguageUrls,proto3" json:"sign_language_urls,omitempty"`
-	Options          []*Option              `protobuf:"bytes,6,rep,name=options,proto3" json:"options,omitempty"`
+	Description      string                 `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
+	Image            string                 `protobuf:"bytes,5,opt,name=image,proto3" json:"image,omitempty"`
+	SignLanguageUrls []string               `protobuf:"bytes,6,rep,name=sign_language_urls,json=signLanguageUrls,proto3" json:"sign_language_urls,omitempty"`
+	Options          []*Option              `protobuf:"bytes,7,rep,name=options,proto3" json:"options,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -210,6 +211,13 @@ func (x *ViewMenuDetail) GetMenuPrice() int32 {
 		return x.MenuPrice
 	}
 	return 0
+}
+
+func (x *ViewMenuDetail) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
 }
 
 func (x *ViewMenuDetail) GetImage() string {
@@ -752,15 +760,16 @@ const file_menu_proto_rawDesc = "" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1d\n" +
 	"\n" +
 	"menu_price\x18\x03 \x01(\x05R\tmenuPrice\x12\x14\n" +
-	"\x05image\x18\x04 \x01(\tR\x05image\"\xc6\x01\n" +
+	"\x05image\x18\x04 \x01(\tR\x05image\"\xe8\x01\n" +
 	"\x0eViewMenuDetail\x12\x1a\n" +
 	"\bcategory\x18\x01 \x01(\tR\bcategory\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1d\n" +
 	"\n" +
-	"menu_price\x18\x03 \x01(\x05R\tmenuPrice\x12\x14\n" +
-	"\x05image\x18\x04 \x01(\tR\x05image\x12,\n" +
-	"\x12sign_language_urls\x18\x05 \x03(\tR\x10signLanguageUrls\x12!\n" +
-	"\aoptions\x18\x06 \x03(\v2\a.OptionR\aoptions\"\xc6\x02\n" +
+	"menu_price\x18\x03 \x01(\x05R\tmenuPrice\x12 \n" +
+	"\vdescription\x18\x04 \x01(\tR\vdescription\x12\x14\n" +
+	"\x05image\x18\x05 \x01(\tR\x05image\x12,\n" +
+	"\x12sign_language_urls\x18\x06 \x03(\tR\x10signLanguageUrls\x12!\n" +
+	"\aoptions\x18\a \x03(\v2\a.OptionR\aoptions\"\xc6\x02\n" +
 	"\x11CreateMenuRequest\x12\x1d\n" +
 	"\n" +
 	"store_code\x18\x01 \x01(\tR\tstoreCode\x12\x1a\n" +

--- a/server/internal/pkg/grpc/menu.go
+++ b/server/internal/pkg/grpc/menu.go
@@ -1,7 +1,6 @@
 package grpcHandler
 
 import (
-	"context"
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	pb "server/gen"
@@ -11,7 +10,7 @@ import (
 	"server/internal/pkg/utils"
 )
 
-func (s *Server) CreateMenu(ctx context.Context, req *pb.CreateMenuRequest) (res *pb.CreateMenuResponse, errRes error) {
+func (s *Server) CreateMenu(req *pb.CreateMenuRequest) (res *pb.CreateMenuResponse, errRes error) {
 	defer func() {
 		if r := recover(); r != nil {
 			logrus.Error("[gRPC CreateMenu] panic: ", r)
@@ -62,7 +61,7 @@ func (s *Server) CreateMenu(ctx context.Context, req *pb.CreateMenuRequest) (res
 	}, nil
 }
 
-func (s *Server) GetCategoryList(ctx context.Context, req *pb.GetCategoryListRequest) (res *pb.GetCategoryListResponse, errRes error) {
+func (s *Server) GetCategoryList(req *pb.GetCategoryListRequest) (res *pb.GetCategoryListResponse, errRes error) {
 	defer func() {
 		if r := recover(); r != nil {
 			logrus.Error("[gRPC GetCategoryList] panic: ", r)
@@ -91,7 +90,7 @@ func (s *Server) GetCategoryList(ctx context.Context, req *pb.GetCategoryListReq
 	}, nil
 }
 
-func (s *Server) GetMenuList(ctx context.Context, req *pb.GetMenuListRequest) (res *pb.GetMenuListResponse, errRes error) {
+func (s *Server) GetMenuList(req *pb.GetMenuListRequest) (res *pb.GetMenuListResponse, errRes error) {
 	defer func() {
 		if r := recover(); r != nil {
 			logrus.Error("[gRPC GetMenuList] panic: ", r)
@@ -138,7 +137,7 @@ func (s *Server) GetMenuList(ctx context.Context, req *pb.GetMenuListRequest) (r
 	}, nil
 }
 
-func (s *Server) GetMenuDetail(ctx context.Context, req *pb.GetMenuDetailRequest) (res *pb.GetMenuDetailResponse, errRes error) {
+func (s *Server) GetMenuDetail(req *pb.GetMenuDetailRequest) (res *pb.GetMenuDetailResponse, errRes error) {
 	defer func() {
 		if r := recover(); r != nil {
 			logrus.Error("[gRPC GetMenuDetail] panic: ", r)
@@ -197,6 +196,7 @@ func (s *Server) GetMenuDetail(ctx context.Context, req *pb.GetMenuDetailRequest
 			Category:         mMenu.Category,
 			Name:             mMenu.Name,
 			MenuPrice:        mMenu.MenuPrice,
+			Description:      mMenu.Description,
 			Image:            mMenu.Image,
 			SignLanguageUrls: mMenu.SignLanguageURLs,
 			Options:          options,

--- a/server/proto/menu.proto
+++ b/server/proto/menu.proto
@@ -21,9 +21,10 @@ message ViewMenuDetail{
   string category = 1;
   string name = 2;
   int32 menu_price = 3;
-  string image = 4;
-  repeated string sign_language_urls = 5;
-  repeated Option options = 6;
+  string description = 4;
+  string image = 5;
+  repeated string sign_language_urls = 6;
+  repeated Option options = 7;
 }
 
 message CreateMenuRequest {


### PR DESCRIPTION
## 이슈
#176 

## 변경사항
- UI 디자인 변경에 따라 `GetMenuDetail` 응답 형식에 `description` 필드 추가
- `menu.proto`의 `ViewMenuDetail` 메시지에 `string description` 필드 추가
- gRPC 핸들러의 `GetMenuDetail` 응답에 `description` 값 매핑
- REST API에서도 동일한 응답 형태를 반환하도록 수정
- API 명세서(description 포함) 업데이트

## 📂 변경 파일
- `proto/menu.proto`
- `server/internal/pkg/grpc/menu.go`
- `server/proto/menu.proto`
- 이외 `pb.go` 파일

## ✅ 테스트
- 로컬에서 gRPC 및 REST API 호출 시 `description` 필드 정상 반환 확인
<img width="726" alt="스크린샷 2025-05-28 오후 8 03 09" src="https://github.com/user-attachments/assets/bf7f280f-921a-4691-bbff-7b775902ae80" />
