### PR TITLE
server/fix/menu - 2 : 함수 시그니처 일치

### DIFF
--- a/server/internal/pkg/grpc/menu.go
+++ b/server/internal/pkg/grpc/menu.go
@@ -1,6 +1,7 @@
 package grpcHandler
 
 import (
+	"context"
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	pb "server/gen"
@@ -10,7 +11,7 @@ import (
 	"server/internal/pkg/utils"
 )
 
-func (s *Server) CreateMenu(req *pb.CreateMenuRequest) (res *pb.CreateMenuResponse, errRes error) {
+func (s *Server) CreateMenu(ctx context.Context, req *pb.CreateMenuRequest) (res *pb.CreateMenuResponse, errRes error) {
 	defer func() {
 		if r := recover(); r != nil {
 			logrus.Error("[gRPC CreateMenu] panic: ", r)
@@ -61,7 +62,7 @@ func (s *Server) CreateMenu(req *pb.CreateMenuRequest) (res *pb.CreateMenuRespon
 	}, nil
 }
 
-func (s *Server) GetCategoryList(req *pb.GetCategoryListRequest) (res *pb.GetCategoryListResponse, errRes error) {
+func (s *Server) GetCategoryList(ctx context.Context, req *pb.GetCategoryListRequest) (res *pb.GetCategoryListResponse, errRes error) {
 	defer func() {
 		if r := recover(); r != nil {
 			logrus.Error("[gRPC GetCategoryList] panic: ", r)
@@ -90,7 +91,7 @@ func (s *Server) GetCategoryList(req *pb.GetCategoryListRequest) (res *pb.GetCat
 	}, nil
 }
 
-func (s *Server) GetMenuList(req *pb.GetMenuListRequest) (res *pb.GetMenuListResponse, errRes error) {
+func (s *Server) GetMenuList(ctx context.Context, req *pb.GetMenuListRequest) (res *pb.GetMenuListResponse, errRes error) {
 	defer func() {
 		if r := recover(); r != nil {
 			logrus.Error("[gRPC GetMenuList] panic: ", r)
@@ -137,7 +138,7 @@ func (s *Server) GetMenuList(req *pb.GetMenuListRequest) (res *pb.GetMenuListRes
 	}, nil
 }
 
-func (s *Server) GetMenuDetail(req *pb.GetMenuDetailRequest) (res *pb.GetMenuDetailResponse, errRes error) {
+func (s *Server) GetMenuDetail(ctx context.Context, req *pb.GetMenuDetailRequest) (res *pb.GetMenuDetailResponse, errRes error) {
 	defer func() {
 		if r := recover(); r != nil {
 			logrus.Error("[gRPC GetMenuDetail] panic: ", r)


### PR DESCRIPTION
##  문제 상황
기존 커밋에서 `GetMenuDetail` gRPC 함수의 시그니처에 `context.Context` 파라미터가 누락되어 있어,
gRPC 인터페이스(`APIServiceServer`)와 불일치가 발생

이로 인해 CI/CD에서 다음과 같은 에러가 발생
<img width="569" alt="스크린샷 2025-05-28 오후 8 31 18" src="https://github.com/user-attachments/assets/a933105f-2146-47af-8d10-b5df1a67fcbb" />

## 변경 사항
- `GetMenuDetail` 함수 시그니처를 `ctx context.Context` 포함한 형태로 수정
- `menu.proto` 변경 사항(`description` 필드 추가)에 맞춰 proto 파일 재생성
- 변경된 `.pb.go` 파일을 커밋하여 인터페이스 불일치 해결
- 
## 확인 사항
- 로컬에서 `go build ./...` 정상 빌드 확인
- `make proto` 이후 `.pb.go` 파일 변경사항 반영됨
- CI/CD 파이프라인 정상 통과 확인 